### PR TITLE
Bugfix datatype where hash is treated as an array

### DIFF
--- a/lib/exponent-server-sdk.rb
+++ b/lib/exponent-server-sdk.rb
@@ -73,17 +73,19 @@ module Exponent
       end
 
       def handle_success(response)
-        extract_data(response).tap do |data|
-          validate_status(data.fetch('status'), response)
-        end
+        extract_data(response)
       end
 
       def extract_data(response)
         data = response.fetch('data')
-        if data.class == Array
-          data.first
-        else
+        if data.is_a? Hash
+          validate_status(data.fetch('status'), response)
           data
+        else
+          data.map do |receipt|
+            validate_status(receipt.fetch('status'), response)
+            receipt
+          end
         end
       end
 

--- a/lib/exponent-server-sdk.rb
+++ b/lib/exponent-server-sdk.rb
@@ -79,7 +79,12 @@ module Exponent
       end
 
       def extract_data(response)
-        response.fetch('data').first
+        data = response.fetch('data')
+        if data.class == Array
+          data.first
+        else
+          data
+        end
       end
 
       def validate_status(status, response)


### PR DESCRIPTION
This PR resolves a datatyping error where the response is a `Hash` instead of an `Array`.

When the response object is an array, the current implementation works. However, there is a case in which the response is a `Hash`, in which case the method

```ResponseHandler.extract_data```

grabs only the first `key => value` pair from the object in conjunction with turning it into an array, i.e.

```
["id", "5ff3829e-48b2-40c3-8559-7240697ee912"]
```

This results in an error being thrown in this method.

```
ResponseHandler.validate_status
```

```
TypeError (no implicit conversion of String into Integer):
```

# Screen shot of error:
![screen shot 2019-01-08 at 11 03 59 am](https://user-images.githubusercontent.com/16382165/50809498-74306080-1336-11e9-833c-8a4ecd940d39.jpg)

# Working implementation after update:
![screen shot 2019-01-08 at 11 04 30 am](https://user-images.githubusercontent.com/16382165/50809503-798dab00-1336-11e9-872e-b2e8e83ff0d8.jpg)


Please let me know if there's anything else you'd need to get this PR merged.

Thanks!