### PR TITLE
Fix Rakefile to actually run tests.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,19 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-Rake::TestTask.new(:test) do |t|
+def load_libs(t)
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList['test/**/*-manual_test.rb']
+end
+
+Rake::TestTask.new(:test) do |t|
+  load_libs t
+  t.test_files = FileList['test/**/*-test.rb']
+end
+
+Rake::TestTask.new(:manual_test) do |t|
+  load_libs t
+  t.test_files = FileList['manual_test.rb']
 end
 
 task :default => :test


### PR DESCRIPTION
Fixes a regression introduced by #20 where `rake test` does not actually run the tests.

Reproduction steps:

1. Run `rake` or `rake test`
1. No specs are run

Or, look at [a recent build](https://travis-ci.org/expo/expo-server-sdk-ruby/jobs/497067923#L506) and see evidence that no specs are run.

This PR fixes the behavior of `rake` and `rake test` to the original intended behavior and introduces a `rake manual_test` which allows for running the `manual_test.rb` file.